### PR TITLE
支持非抢先验证的客户端

### DIFF
--- a/proxy/http/server.go
+++ b/proxy/http/server.go
@@ -111,7 +111,7 @@ Start:
 	if len(s.config.Accounts) > 0 {
 		user, pass, ok := parseBasicAuth(request.Header.Get("Proxy-Authorization"))
 		if !ok || !s.config.HasAccount(user, pass) {
-			return common.Error2(conn.Write([]byte("HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"proxy\"\r\n\r\n")))
+			return common.Error2(conn.Write([]byte([]byte("HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"proxy\"\r\nConnection: close\r\n\r\n")))
 		}
 		if inbound != nil {
 			inbound.User.Email = user


### PR DESCRIPTION
非抢先验证是指建立隧道时不会主动发送Proxy-Authorization，在之后收到407响应后才会再带上这个验证。

服务端目前在代理验证不通过时现在将直接关闭连接，而客户端在不知情的情况下仍会在这个连接中发送请求，导致客户端报错。
因此应在关闭连接时明确返回close。

受此影响的客户端：okhttp3 <= 3.11.0